### PR TITLE
remove user-agent header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@petfinder/petfinder-js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2790,9 +2790,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@petfinder/petfinder-js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Petfinder API client",
   "repository": {
     "type": "git",

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ export class Client {
         this.config = config;
         this.http = axios.create({
             baseURL: config.baseUrl || "https://api.petfinder.com/v2",
-            headers: {"User-Agent": "petfinder-js-sdk/v1.0 (https://github.com/petfinder-com/petfinder-js-sdk)"},
+            headers: {"x-api-sdk": "petfinder-js-sdk/v1.0 (https://github.com/petfinder-com/petfinder-js-sdk)"},
         });
 
         this.http.interceptors.response.use((response: AxiosResponse) => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -61,7 +61,7 @@ it("Should be able to get sub clients", () => {
     expect(client.organization).toBeInstanceOf(Organization);
 });
 
-it("Should include an identifiable user agent", async () => {
+it("Should include an identifiable header", async () => {
     const mock = new MockAdapter(axios);
     mock.onGet("/").replyOnce(200);
 
@@ -70,6 +70,6 @@ it("Should include an identifiable user agent", async () => {
 
     expect(response.status).toEqual(200);
     expect(mock.history.get.length).toEqual(1);
-    expect(mock.history.get[0].headers["User-Agent"])
+    expect(mock.history.get[0].headers["x-api-sdk"])
         .toEqual("petfinder-js-sdk/v1.0 (https://github.com/petfinder-com/petfinder-js-sdk)");
 });


### PR DESCRIPTION
Chrome and Safari won't set this header when making requests, so use a
new x- header to track sdk usage.

fixes #4